### PR TITLE
Chat realtime update

### DIFF
--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -42,6 +42,32 @@ export const Chat = props => {
   };
 
   const getMessages = async () => {
+    const messagesSnapshot = await firebase
+      .firestore()
+      .collection("chats")
+      .doc(chatId)
+      .collection("messages")
+      .orderBy("createdAt", "desc")
+      .get();
+
+    const pastMessages = messagesSnapshot.docs.map(doc => {
+      const avatar = doc.data().senderId === user.id ? user.avatarUrl : null;
+
+      return {
+        _id: doc.id,
+        text: doc.data().text,
+        createdAt: doc.data().createdAt.toDate(),
+        user: {
+          _id: doc.data().senderId,
+          avatar
+        }
+      };
+    });
+
+    setMessages(pastMessages);
+  };
+
+  const listenNewMessages = () => {
     firebase
       .firestore()
       .collection("chats")
@@ -69,34 +95,11 @@ export const Chat = props => {
           }
         });
       });
-
-    const messagesSnapshot = await firebase
-      .firestore()
-      .collection("chats")
-      .doc(chatId)
-      .collection("messages")
-      .orderBy("createdAt", "desc")
-      .get();
-
-    const pastMessages = messagesSnapshot.docs.map(doc => {
-      const avatar = doc.data().senderId === user.id ? user.avatarUrl : null;
-
-      return {
-        _id: doc.id,
-        text: doc.data().text,
-        createdAt: doc.data().createdAt.toDate(),
-        user: {
-          _id: doc.data().senderId,
-          avatar
-        }
-      };
-    });
-
-    setMessages(pastMessages);
   };
 
   useEffect(() => {
     getMessages();
+    listenNewMessages();
   }, []);
 
   return (

--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -49,6 +49,10 @@ export const Chat = props => {
       .collection("messages")
       .orderBy("createdAt", "desc")
       .onSnapshot(querySnapShot => {
+        if (querySnapShot.metadata.hasPendingWrites) {
+          return null;
+        }
+
         querySnapShot.docChanges().forEach(change => {
           if (change.type === "added") {
             console.log("New: ", change.doc.data());

--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -41,32 +41,6 @@ export const Chat = props => {
     }
   };
 
-  const getMessages = async () => {
-    const messagesSnapshot = await firebase
-      .firestore()
-      .collection("chats")
-      .doc(chatId)
-      .collection("messages")
-      .orderBy("createdAt", "desc")
-      .get();
-
-    const pastMessages = messagesSnapshot.docs.map(doc => {
-      const avatar = doc.data().senderId === user.id ? user.avatarUrl : null;
-
-      return {
-        _id: doc.id,
-        text: doc.data().text,
-        createdAt: doc.data().createdAt.toDate(),
-        user: {
-          _id: doc.data().senderId,
-          avatar
-        }
-      };
-    });
-
-    setMessages(pastMessages);
-  };
-
   const listenNewMessages = () => {
     firebase
       .firestore()
@@ -82,13 +56,16 @@ export const Chat = props => {
         querySnapShot.docChanges().forEach(change => {
           if (change.type === "added") {
             console.log("New: ", change.doc.data());
+            const avatar =
+              change.doc.data().senderId === user.id ? user.avatarUrl : null;
+
             const addedMessage = {
               _id: change.doc.id,
               text: change.doc.data().text,
               createdAt: change.doc.data().createdAt.toDate(),
               user: {
                 _id: change.doc.data().senderId,
-                avatar: user.avatarUrl
+                avatar
               }
             };
             setMessages(prevMessages => [addedMessage, ...prevMessages]);
@@ -98,7 +75,6 @@ export const Chat = props => {
   };
 
   useEffect(() => {
-    getMessages();
     listenNewMessages();
   }, []);
 

--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -41,7 +41,7 @@ export const Chat = props => {
     }
   };
 
-  const listenNewMessages = () => {
+  const getMessages = () => {
     firebase
       .firestore()
       .collection("chats")
@@ -75,7 +75,7 @@ export const Chat = props => {
   };
 
   useEffect(() => {
-    listenNewMessages();
+    getMessages();
   }, []);
 
   return (

--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -42,6 +42,30 @@ export const Chat = props => {
   };
 
   const getMessages = async () => {
+    firebase
+      .firestore()
+      .collection("chats")
+      .doc(chatId)
+      .collection("messages")
+      .orderBy("createdAt", "desc")
+      .onSnapshot(querySnapShot => {
+        querySnapShot.docChanges().forEach(change => {
+          if (change.type === "added") {
+            console.log("New: ", change.doc.data());
+            const addedMessage = {
+              _id: change.doc.id,
+              text: change.doc.data().text,
+              createdAt: change.doc.data().createdAt.toDate(),
+              user: {
+                _id: change.doc.data().senderId,
+                avatar: user.avatarUrl
+              }
+            };
+            setMessages(prevMessages => [addedMessage, ...prevMessages]);
+          }
+        });
+      });
+
     const messagesSnapshot = await firebase
       .firestore()
       .collection("chats")

--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -49,6 +49,7 @@ export const Chat = props => {
       .collection("messages")
       .orderBy("createdAt", "desc")
       .onSnapshot(querySnapShot => {
+        // https://firebase.google.com/docs/firestore/query-data/listen#events-local-changes
         if (querySnapShot.metadata.hasPendingWrites) {
           return null;
         }

--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -53,13 +53,13 @@ export const Chat = props => {
           return null;
         }
 
-        querySnapShot.docChanges().forEach(change => {
+        const addedMessages = querySnapShot.docChanges().map(change => {
           if (change.type === "added") {
             console.log("New: ", change.doc.data());
             const avatar =
               change.doc.data().senderId === user.id ? user.avatarUrl : null;
 
-            const addedMessage = {
+            return {
               _id: change.doc.id,
               text: change.doc.data().text,
               createdAt: change.doc.data().createdAt.toDate(),
@@ -68,9 +68,9 @@ export const Chat = props => {
                 avatar
               }
             };
-            setMessages(prevMessages => [addedMessage, ...prevMessages]);
           }
         });
+        setMessages(prevMessages => [...addedMessages, ...prevMessages]);
       });
   };
 

--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -72,7 +72,9 @@ export const Chat = props => {
     setLastCreatedAt(lastMessage.createdAt);
   };
 
-  const listenMessage = () => {
+  // I try to listen only new updates.
+  // https://stackoverflow.com/questions/53156109/how-to-skip-initial-data-and-trigger-only-new-updates-in-firestore-firebase
+  const realTimeUpdateMessage = () => {
     if (!lastCreatedAt) {
       return null;
     }
@@ -123,7 +125,7 @@ export const Chat = props => {
   }, []);
 
   useEffect(() => {
-    listenMessage();
+    realTimeUpdateMessage();
   }, [lastCreatedAt]);
 
   return (


### PR DESCRIPTION
## Why

Closes #25 

## Have to try

ドキュメントのリッスンするようになると最初に今までのメッセージ全件取得する時に、メッセージ1件ごとに `added` イベント発火、つまり読み込み1回が発生する。（保存されているメッセージn件分の読み込みが毎度発生するということ）
初期状態の added イベントのみ発火させないようにする方法を考える必要がある。

https://firebase.google.com/docs/firestore/query-data/listen#view_changes_between_snapshots

> 最初のクエリ スナップショットには、クエリに一致する既存のすべてのドキュメントの added イベントが含まれています。これは、クエリの初期状態に対してクエリ スナップショットが最新の状態になるように、一連の変更を取得しているためです。たとえば、最初のクエリ スナップショットで受け取った変更から、初期状態を処理する特別なロジックを追加する必要なく、UI を直接入力することができます。

https://firebase.google.com/docs/firestore/pricing#operations

> クエリの結果をリッスンする場合、結果セット内のドキュメントを追加または更新するたびに、1 回の読み取りとして課金されます。

### 結論

👇でうまくいった。

ref. https://stackoverflow.com/questions/53156109/how-to-skip-initial-data-and-trigger-only-new-updates-in-firestore-firebase

> What you can do instead, is to add add under each user object a Date property (this is how you can add it) and query your database on client, according to this new property, for all documents that have changed since a previous time.

つまり listen するための snapshot として以前の最新のメッセージが保存された時間より新しいメッセージだけ取得するようにすれば良い。

868ca1c でそうしたらうまくいった。

### 試してみたこと

- ~listener には limit をかけ、get は全件取得~
    - うまくいかなかった（それぞれ別の配列として認識され、初期化が何度も行われることになった）
- ~messages を配列で保存~
    - added で取れなくなり modified で見ないといけないのでキツい