### PR TITLE
Cleanup subscription in firebase

### DIFF
--- a/src/containers/Chat.tsx
+++ b/src/containers/Chat.tsx
@@ -81,7 +81,7 @@ export const Chat = props => {
 
     console.log("lastCreated:", lastCreatedAt);
 
-    firebase
+    return firebase
       .firestore()
       .collection("chats")
       .doc(chatId)
@@ -125,7 +125,11 @@ export const Chat = props => {
   }, []);
 
   useEffect(() => {
-    realTimeUpdateMessage();
+    const unsubscribe = realTimeUpdateMessage();
+    return () => {
+      // onSnapshot は null のままの時もあるのでこうしている
+      if (unsubscribe != null) unsubscribe();
+    };
   }, [lastCreatedAt]);
 
   return (

--- a/src/containers/Discover.tsx
+++ b/src/containers/Discover.tsx
@@ -50,8 +50,13 @@ export const Discover = props => {
   };
 
   useEffect(() => {
-    firebase.auth().onAuthStateChanged(user => setCurrentUserId(user.uid));
+    const unsubscribe = firebase
+      .auth()
+      .onAuthStateChanged(user => setCurrentUserId(user.uid));
+
     getDiscoverUsers();
+
+    return () => unsubscribe();
   }, [currentUserId]);
 
   const getDiscoverUsers = async () => {

--- a/src/containers/Discover.tsx
+++ b/src/containers/Discover.tsx
@@ -5,7 +5,7 @@ import { DiscoverScreen } from "../screens/DiscoverScreen";
 
 export const Discover = props => {
   const [users, setUsers] = useState([]);
-  const [currentUserId, setCurrentUserId] = useState();
+  const [currentUserId, setCurrentUserId] = useState(null);
 
   const likesPress = user => async () => {
     try {

--- a/src/containers/Liked.tsx
+++ b/src/containers/Liked.tsx
@@ -50,8 +50,11 @@ export const Liked = props => {
   };
 
   useEffect(() => {
-    firebase.auth().onAuthStateChanged(user => setCurrentUserId(user.uid));
+    const unsubscribe = firebase
+      .auth()
+      .onAuthStateChanged(user => setCurrentUserId(user.uid));
     getLikedUsers();
+    return () => unsubscribe();
   }, [currentUserId]);
 
   const getLikedUsers = async () => {

--- a/src/containers/Liked.tsx
+++ b/src/containers/Liked.tsx
@@ -5,7 +5,7 @@ import { DiscoverScreen } from "../screens/DiscoverScreen";
 
 export const Liked = props => {
   const [users, setUsers] = useState([]);
-  const [currentUserId, setCurrentUserId] = useState();
+  const [currentUserId, setCurrentUserId] = useState(null);
 
   const thanksPress = user => async () => {
     try {

--- a/src/containers/Liked.tsx
+++ b/src/containers/Liked.tsx
@@ -58,18 +58,19 @@ export const Liked = props => {
   }, [currentUserId]);
 
   const getLikedUsers = async () => {
-    // TODO: 実装する
-    firebase
-      .firestore()
-      .collection("users")
-      .onSnapshot(querySnapShot => {
-        // Snapshot が更新されたらここのコールバックに入ってくる
-        console.log("onsnapshot!!!", querySnapShot);
-      });
-
     if (!currentUserId) {
       return null;
     }
+
+    // TODO: 実装する
+    // これも clean up 時に unsubscribe しないといけないので一旦コメントアウトしている
+    // firebase
+    //   .firestore()
+    //   .collection("users")
+    //   .onSnapshot(querySnapShot => {
+    //     // Snapshot が更新されたらここのコールバックに入ってくる
+    //     console.log("onsnapshot!!!", querySnapShot);
+    //   });
 
     const usersSnapshot = await firebase
       .firestore()

--- a/src/containers/Message.tsx
+++ b/src/containers/Message.tsx
@@ -20,8 +20,13 @@ export const Message = props => {
   };
 
   useEffect(() => {
-    firebase.auth().onAuthStateChanged(user => setCurrentUserId(user.uid));
+    const unsubscribe = firebase
+      .auth()
+      .onAuthStateChanged(user => setCurrentUserId(user.uid));
+
     getMatchUsers();
+
+    return () => unsubscribe();
   }, [currentUserId]);
 
   const getMatchUsers = async () => {

--- a/src/containers/Message.tsx
+++ b/src/containers/Message.tsx
@@ -5,7 +5,7 @@ import { MessageScreen } from "../screens/MessageScreen";
 
 export const Message = props => {
   const [users, setUsers] = useState([]);
-  const [currentUserId, setCurrentUserId] = useState();
+  const [currentUserId, setCurrentUserId] = useState(null);
 
   const navigateChat = user => () => {
     props.navigation.navigate("Chat", {

--- a/src/screens/EditProfileScreen.tsx
+++ b/src/screens/EditProfileScreen.tsx
@@ -42,12 +42,16 @@ export const EditProfileScreen = props => {
 
   // TODO: useCurrentUser 的な感じで抽象化したい、返り値は CurrentUser のオブジェクトのイメージ
   useEffect(() => {
+    const unsubscribe = firebase
+      .auth()
+      .onAuthStateChanged(user => setUserID(user.uid));
+
     getCurrentUser();
+
+    return () => unsubscribe();
   }, [userId]);
 
   const getCurrentUser = async () => {
-    firebase.auth().onAuthStateChanged(user => setUserID(user.uid));
-
     if (!userId) {
       return null;
     }


### PR DESCRIPTION
## Why

Fix #8 

## How

https://github.com/daido1976/mathern/issues/8#issuecomment-553524671

> firebase auth を unsubscribe してなかったのが原因だった。
> あと、リアルタイムアップデートの方も unsubscribe が必要。

両方とも firebase の関数が unsubscibe 関数を返すので、それを useEffect のクリーンアップ関数として呼べば良い。

refs.
- https://usehooks.com/useAuth/
- https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#returns-firebase.unsubscribe
- https://firebase.google.com/docs/firestore/query-data/listen#detach_a_listener
- https://firebase.google.com/docs/reference/node/firebase.firestore.CollectionReference.html#returns-function
- https://stackoverflow.com/questions/46642652/how-to-remove-listener-for-documentsnapshot-events-google-cloud-firestore